### PR TITLE
fix: z-index of dashboard_holder

### DIFF
--- a/PixelPlurk.css
+++ b/PixelPlurk.css
@@ -119,6 +119,7 @@
 /* 細長發噗區 */
 #dashboard_holder {
   padding-top: 0;
+  z-index: 10;
 }
 #plurk-dashboard .dash-group-form {
   width: 100%;


### PR DESCRIPTION
Originally
<img width="463" alt="image" src="https://user-images.githubusercontent.com/4176802/231823076-f1fdf74b-f88b-450e-bb57-b3ff9f412190.png">
Now set dashboard z-index to 10